### PR TITLE
Updating parent POM version to 1.11.6

### DIFF
--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -5,9 +5,9 @@
   <parent>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk-pom</artifactId>
-    <version>1.11.6-SNAPSHOT</version>
+    <version>1.11.6</version>
   </parent>
-  <groupId>com.amazonaws</groupId>
+  <groupId>twigkit</groupId>
   <artifactId>aws-java-sdk-core</artifactId>
   <name>AWS SDK for Java - Core</name>
   <description>The AWS SDK for Java - Core module holds the classes that is used by the individual service clients to interact with Amazon Web Services. Users need to depend on aws-java-sdk artifact for accessing individual client classes.</description>


### PR DESCRIPTION
The snapshot moved on to 1.11.7-SNAPSHOT so moving SDK POM version to 1.11.6
