### PR TITLE
Releasing version 1.11.6

### DIFF
--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -8,7 +8,7 @@
     <version>1.11.6</version>
   </parent>
   <groupId>twigkit</groupId>
-  <version>1.11</version>
+  <version>1.11.6</version>
   <artifactId>aws-java-sdk-core</artifactId>
   <name>AWS SDK for Java - Core</name>
   <description>The AWS SDK for Java - Core module holds the classes that is used by the individual service clients to interact with Amazon Web Services. Users need to depend on aws-java-sdk artifact for accessing individual client classes.</description>

--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -8,6 +8,7 @@
     <version>1.11.6</version>
   </parent>
   <groupId>twigkit</groupId>
+  <version>1.11</version>
   <artifactId>aws-java-sdk-core</artifactId>
   <name>AWS SDK for Java - Core</name>
   <description>The AWS SDK for Java - Core module holds the classes that is used by the individual service clients to interact with Amazon Web Services. Users need to depend on aws-java-sdk artifact for accessing individual client classes.</description>


### PR DESCRIPTION
See https://jira.lucidworks.com/browse/AK-2930 - moving AK AWS core SDK from `1.11.6-SNAPSHOT` to `1.11.6`